### PR TITLE
The dart math package has removed the PI constant

### DIFF
--- a/lib/src/formula/spherical_lawofcosines.dart
+++ b/lib/src/formula/spherical_lawofcosines.dart
@@ -7,7 +7,7 @@ class Spherical_LawOfCosines {
             cos(lat1) * cos(lat2) *
             cos(lon2 - lon1)
         );
-        if (distance < 0) distance = distance + PI;
+        if (distance < 0) distance = distance + pi;
 
         var EarthRadius = 6378137.0; // WGS84 major axis
         return EarthRadius * distance;

--- a/lib/src/great_circle_distance_base.dart
+++ b/lib/src/great_circle_distance_base.dart
@@ -58,7 +58,7 @@ class GreatCircleDistance {
         return Vincenty.distance(this.latitude1, this.longitude1, this.latitude2, this.longitude2);
     }
 
-    double _radiansFromDegrees(final double degrees) => degrees * (PI / 180.0);
+    double _radiansFromDegrees(final double degrees) => degrees * (pi / 180.0);
 
     /// A coordinate is considered invalid if it meets at least one of the following criteria:
     ///


### PR DESCRIPTION
The dart math package has removed some deprecated constants, including PI.