### PR TITLE
Updated for Dart 2.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-# Great-circle distance [![Pub][pub_version]](../../) ![Travis status][travis_status] [![Coverage Status][coverage_status]][coverage_page]
+# Great Circle Distance [![Pub][pub_version]](../../) ![Travis status][travis_status] [![Coverage Status][coverage_status]][coverage_page]
+
+**Updated to work with Flutter 1.9 and Dart 2.5**
 
 Calculate the great-circle distance between two points (having Latitude,Longitude) on the surface of Earth 
 You can get the distance using the Spherical law of cosines, Haversine formula or Vincenty`s formula  

--- a/lib/src/formula/spherical_lawofcosines.dart
+++ b/lib/src/formula/spherical_lawofcosines.dart
@@ -7,7 +7,7 @@ class Spherical_LawOfCosines {
             cos(lat1) * cos(lat2) *
             cos(lon2 - lon1)
         );
-        if (distance < 0) distance = distance + PI;
+        if (distance < 0) distance = distance + pi;
 
         var EarthRadius = 6378137.0; // WGS84 major axis
         return EarthRadius * distance;

--- a/lib/src/great_circle_distance_base.dart
+++ b/lib/src/great_circle_distance_base.dart
@@ -58,7 +58,7 @@ class GreatCircleDistance {
         return Vincenty.distance(this.latitude1, this.longitude1, this.latitude2, this.longitude2);
     }
 
-    double _radiansFromDegrees(final double degrees) => degrees * (PI / 180.0);
+    double _radiansFromDegrees(final double degrees) => degrees * (pi / 180.0);
 
     /// A coordinate is considered invalid if it meets at least one of the following criteria:
     ///


### PR DESCRIPTION
Replaced all `PI` instances with `pi` (uppercase -> lowercase) in order to work with the latest math library of Dart 2.5 and Flutter 1.9.